### PR TITLE
enable HMI_wallpaper command type

### DIFF
--- a/nspanel.be
+++ b/nspanel.be
@@ -55,6 +55,7 @@ class NSPanel : Driver
     "weather":    0x81,
     "queryInfo":  0x80,
     "HMI_dimOpen":  0x87,
+    "HMI_wallpaper":0x87,
   }
   static header = bytes('55AA') 
 


### PR DESCRIPTION
to enable wallpaper change (FW 1.4+) the type for HMI_wallpaper must be set to 0x87